### PR TITLE
Fix implied export default with satisfies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.6",
-    "content-tag": "^3.1.1",
+    "content-tag": "^3.1.2",
     "prettier": "^3.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.23.6
         version: 7.26.0
       content-tag:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.1.2
+        version: 3.1.2
       prettier:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1986,8 +1986,8 @@ packages:
       proto-list: 1.2.4
     dev: true
 
-  /content-tag@3.1.1:
-    resolution: {integrity: sha512-94puwVk6X8oJcbRIEY03UM80zWzA3dYgGkOiRJzeY1vXgwrFUh3OolDDi/D7YBa6Vsx+CgAvuk4uXlB8loZ1FA==}
+  /content-tag@3.1.2:
+    resolution: {integrity: sha512-Z+MGhZfnFFKzYC+pUTWXnoDYhfiXP9ojZe3JbwsYufmDuoeq2EvuDyeFAJ/RnKokUwz5s9bQhDOrbvSYRShcrQ==}
     dev: false
 
   /convert-source-map@2.0.0:

--- a/src/parse/preprocess.ts
+++ b/src/parse/preprocess.ts
@@ -71,7 +71,7 @@ export function preprocessTemplateRange(
     suffix = '*/}';
 
     const nextToken = code.slice(template.range.end).toString().match(/\S+/);
-    if (nextToken && nextToken[0] === 'as') {
+    if (nextToken && (nextToken[0] === 'as' || nextToken[0] === 'satisfies')) {
       // Replace with parenthesized ObjectExpression
       prefix = '(' + prefix;
       suffix = suffix + ')';

--- a/tests/cases/gts/implied-export-default-satisfies.gts
+++ b/tests/cases/gts/implied-export-default-satisfies.gts
@@ -1,0 +1,5 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+<template>
+  what
+</template> satisfies TemplateOnlyComponent;

--- a/tests/cases/gts/implied-export-default-satisfies.gts
+++ b/tests/cases/gts/implied-export-default-satisfies.gts
@@ -1,5 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 <template>
-  what
+  Implied Export Default with Satisfies
 </template> satisfies TemplateOnlyComponent;

--- a/tests/unit-tests/__snapshots__/format.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/format.test.ts.snap
@@ -453,6 +453,15 @@ export const Exported = <template>
 "
 `;
 
+exports[`format > config > default > it formats ../cases/gts/implied-export-default-satisfies.gts 1`] = `
+"import type { TemplateOnlyComponent } from "@ember/component/template-only";
+
+<template>
+  Implied Export Default with Satisfies
+</template> satisfies TemplateOnlyComponent;
+"
+`;
+
 exports[`format > config > default > it formats ../cases/gts/issue-191.gts 1`] = `
 "import Component from "@glimmer/component";
 

--- a/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
@@ -453,6 +453,15 @@ export const Exported = <template>
 "
 `;
 
+exports[`config > semi: false > it formats ../cases/gts/implied-export-default-satisfies.gts 1`] = `
+"import type { TemplateOnlyComponent } from "@ember/component/template-only"
+
+;<template>
+  Implied Export Default with Satisfies
+</template> satisfies TemplateOnlyComponent
+"
+`;
+
 exports[`config > semi: false > it formats ../cases/gts/issue-191.gts 1`] = `
 "import Component from "@glimmer/component"
 

--- a/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
@@ -453,6 +453,15 @@ export const Exported = <template>
 "
 `;
 
+exports[`config > templateExportDefault: true > it formats ../cases/gts/implied-export-default-satisfies.gts 1`] = `
+"import type { TemplateOnlyComponent } from "@ember/component/template-only";
+
+<template>
+  Implied Export Default with Satisfies
+</template> satisfies TemplateOnlyComponent;
+"
+`;
+
 exports[`config > templateExportDefault: true > it formats ../cases/gts/issue-191.gts 1`] = `
 "import Component from "@glimmer/component";
 


### PR DESCRIPTION
We already had special support to handle an expression followed by typescript `as` keyword, this extends that to also cover the typescript `satisfies` keyword.