### PR TITLE
Repro: #374

### DIFF
--- a/tests/cases/gts/issue-374.gts
+++ b/tests/cases/gts/issue-374.gts
@@ -1,0 +1,11 @@
+import pageTitle from 'ember-page-title/helpers/page-title';
+
+<template>
+  {{pageTitle "TestAppPrettierCharacter"}}
+
+  <h2 id="title">Welcome to Ember</h2>
+
+  {{outlet}}
+
+  …
+</template> satisfies unknown;


### PR DESCRIPTION
Alt to: https://github.com/ember-tooling/prettier-plugin-ember-template-tag/pull/375

Repro for: #374 -- I think it's important that extra content precedes the unicode character 